### PR TITLE
Update README to document PDF fetching and trim requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,18 @@
 
 ## About
 
-One thing that strikes me as odd with Amazon and the documentation on AWS is that there is no download all button, to make it easy to get all the documentation in one go. After creating a simple bash script that kept breaking and needed updating, I decided to rewrite in python to make it a little easier to maintain. You can download Documentation and/or WhitePapers. The script is now pported to Python3 (finally)!
+One thing that strikes me as odd with Amazon and the documentation on AWS is that there is no download all button, to make it easy to get all the documentation in one go. After creating a simple bash script that kept breaking and needed updating, I decided to rewrite in python to make it a little easier to maintain. You can download Documentation and/or WhitePapers as PDFs. The script is now ported to Python3 (finally)!
 
 I hope some of you find this useful.
 
 ## Requirements
 
-Make sure all these python modules are installed as well as Python3:
+You need Python3 plus two third party modules:
 
- - argparse
  - beautifulsoup4
- - urllib3+
- - urlparse3
- - lxml
+ - lxml (provides the `xml` parser beautifulsoup4 is asked for)
+
+Everything else the script uses (`argparse`, `json`, `os`, `urllib`) is part of the Python standard library.
 
 example:
 
@@ -30,13 +29,15 @@ To get all documents:
 ./getAWSdocs.py -d
 ```
 
-Downloading all the docs (290 at the time of writting) can take a long time ~20mins.
+Downloading all the docs (390+ at the time of writing) can take a very long time - potentially days. PDFs are saved under `documentation/`, mirroring the path of each guide on docs.aws.amazon.com.
 
 To get all whitepapers:
 
 ```
 ./getAWSdocs.py -w
 ```
+
+Whitepapers are saved under `whitepapers/`.
 
 Files that exist on disk will not be re-downloaded (so by default only new sections/files are downloaded). To override this default and force re-download of files that exist on disk, use
 
@@ -46,6 +47,20 @@ Files that exist on disk will not be re-downloaded (so by default only new secti
 
 __Note:__ You can use a combination of -d and -w to download all documents at once.
 
-Thats it!
+## How it works
 
-Built by Ric: [@ric__harvey](https://twitter.com/ric__harvey)
+For documentation (`-d`), the script walks the AWS docs catalogue in three stages, all done one request at a time:
+
+1. It fetches the top-level landing page and reads the list of services from it.
+2. For each service it fetches that service's landing page, and for each guide listed there it fetches a small `meta-inf/guide-info.json` file to find the URL of the guide's PDF.
+3. It then downloads each PDF and saves it under `documentation/`, mirroring the guide's path on docs.aws.amazon.com.
+
+For whitepapers (`-w`) discovery is simpler: it scrapes the AWS whitepapers index pages directly for links ending in `.pdf` and downloads them into `whitepapers/`.
+
+## Why it's slow
+
+Discovery alone is thousands of small, sequential HTTP requests, and each one waits for the previous to finish before the next begins. Because the work is dominated by network round-trip latency rather than bandwidth, the total time is roughly the number of requests multiplied by the per-request latency - which, across 390+ guides, can stretch into hours or days.
+
+This is a deliberate design decision, not an oversight. Making the requests one at a time keeps the load on Amazon's servers low. Firing them off in parallel would be far faster, but hammering docs.aws.amazon.com with a burst of concurrent requests risks getting your IP rate-limited or banned, or having the traffic flagged as a denial-of-service attack. Running slowly and politely is the safer way to pull the whole catalogue.
+
+That's it!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-argparse
 beautifulsoup4
-urllib3
-urlparse3
 lxml


### PR DESCRIPTION
Describe how document/whitepaper fetching works, why the crawl is intentionally slow (sequential requests to avoid being rate-limited or flagged as a DoS against docs.aws.amazon.com), correct the save-location and doc-count details, and remove the outdated author attribution.

Trim requirements.txt to the only third-party modules the script uses (beautifulsoup4, lxml); argparse/json/os/urllib are standard library and urllib3/urlparse3 were never imported.


Claude-Session: https://claude.ai/code/session_01PNU4YJE7T4owHrBJbwfstZ